### PR TITLE
Disable VSync during loading screen

### DIFF
--- a/FastLoadingScreen/Patches/WaitScreenPatch.cs
+++ b/FastLoadingScreen/Patches/WaitScreenPatch.cs
@@ -11,6 +11,7 @@ namespace Straitjacket.Subnautica.Mods.FastLoadingScreen.Patches
     {
         private static double benchmark = -1;
         private static int frameRate;
+        private static int vSyncCount;
         private static Stopwatch stopwatch;
         private static bool benchmarking;
         [HarmonyPatch(typeof(WaitScreen), nameof(WaitScreen.Show))]
@@ -30,6 +31,9 @@ namespace Straitjacket.Subnautica.Mods.FastLoadingScreen.Patches
                 Logger.LogInfo("Boosting loading times...");
                 frameRate = Application.targetFrameRate;
                 Application.targetFrameRate = -1;
+
+                vSyncCount = QualitySettings.vSyncCount;
+                QualitySettings.vSyncCount = 0;
             }
             stopwatch = Stopwatch.StartNew();
         }
@@ -62,8 +66,9 @@ namespace Straitjacket.Subnautica.Mods.FastLoadingScreen.Patches
             else
             {
                 Logger.LogInfo($"Loading completed in {stopwatch.Elapsed.TotalSeconds:N2}s, " +
-                    $"setting framerate limit per user preferences ({frameRate})");
+                    $"resetting FPS cap and VSync per user preferences ({frameRate}, {vSyncCount})");
                 Application.targetFrameRate = frameRate;
+                QualitySettings.vSyncCount = vSyncCount;
                 if (benchmark >= 0)
                 {
                     Logger.LogMessage($"Loading completed in {stopwatch.Elapsed.TotalSeconds:N2}s, vs. unboosted benchmark of {benchmark:N2}s.");


### PR DESCRIPTION
Disables VSync during the loading screen, as VSync also caps your framerate to your monitor's refresh rate. Enables users with VSync enabled to benefit from the speedboost.